### PR TITLE
force cmake to look for HPX binaries in the specified path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(MSVC)
 endif()
 
 ################################################################################
-find_package(HPX REQUIRED)
+find_package(HPX REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
 find_package(MPI REQUIRED)
 
 ################################################################################


### PR DESCRIPTION
CMake will ignore its library registry so it would stop ignoring the specified hpx binary path
